### PR TITLE
Smoothly reduce car speed before red tl

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -2,6 +2,6 @@
 <launch>
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node">
       <param name="path" value="$(find styx)../../../yolo/tf_models/tiny-yolo.pb" />
-      <param name="enabled" value="false" />
+      <param name="enabled" value="true" />
     </node>
 </launch>


### PR DESCRIPTION
Smoothly reduce car speed before red tl by decreasing wps' speeds as they are closer to tl.
Enabled tl_detector in tl_detector.launch